### PR TITLE
closes #24 : Fix bug whereby stats.json is not created

### DIFF
--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -231,7 +231,7 @@ def run_and_log(logparams, target_outputs, lazy_run, func_name, *args):
 
     # write stats
     stats_path = logparams.get("stats_file")
-    if stats_path and os.path.isfile(stats_path):
+    if stats_path:
         with open(stats_path, 'wb') as f:
             json.dump(STATS, f)
         execute_command("aws s3 cp %s %s/;" % (stats_path, logparams["sample_s3_output_path"]))


### PR DESCRIPTION
open(stats_path, 'wb') creates the file if it doesn't exist, and that's what should happen. 

It so happens that the host_filtering stage creates the stats file explicitly and so everything works.
But Josh submitted a sample with host_filtering skipped, and as a result the stats file never got generated.

The web app checks for the presence of the stats file to determine that the stage has finished successfully, and because the file was missing, it never proceeded to the next stage.