### PR TITLE
small perf improvements and bug fixes

### DIFF
--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -464,27 +464,30 @@ def download_reference_on_remote(ncbitool_path, input_fasta_ncbi_path, version_n
     execute_command(remote_command(command, key_path, remote_username, server_ip))
     return os.path.join(destination_dir, os.path.basename(input_fasta_ncbi_path))
 
-def download_reference_on_remote_with_version_any_source_type(ref_file, dest_dir,
-    local_ncbitool_dest_dir, remote_ncbitool_dest_dir,
-    key_path, remote_username, server_ip, sudo=False):
+def download_reference_on_remote_with_version_any_source_type(
+        ref_file, dest_dir,
+        local_ncbitool_dest_dir, remote_ncbitool_dest_dir,
+        key_path, remote_username, server_ip, sudo=False):
     # Get input reference and version number.
     # If download does not use ncbitool (e.g. direct s3 link), indicate that there is no versioning.
     input_fasta_name = os.path.basename(ref_file)
     if ref_file.startswith("s3://"):
         input_fasta_remote = os.path.join(dest_dir, input_fasta_name)
-        execute_command(remote_command("aws s3 cp --quiet %s %s/" % (input_fasta_remote, ref_file, dest_dir),
-            key_path, remote_username, server_ip))
+        execute_command(remote_command("aws s3 cp --quiet %s %s/" % (ref_file, dest_dir),
+                                       key_path, remote_username, server_ip))
         version_number = VERSION_NONE
     elif ref_file.startswith("ftp://"):
         input_fasta_remote = os.path.join(dest_dir, input_fasta_name)
-        execute_command(remote_command("cd %s; sudo wget %s" % (input_fasta_remote, dest_dir, ref_file),
-            key_path, remote_username, server_ip))
+        execute_command(remote_command("cd %s; sudo wget %s" % (dest_dir, ref_file),
+                                       key_path, remote_username, server_ip))
         version_number = VERSION_NONE
     else:
-        local_ncbitool, remote_ncbitool = install_ncbitool(local_ncbitool_dest_dir, remote_ncbitool_dest_dir,
+        local_ncbitool, remote_ncbitool = install_ncbitool(
+            local_ncbitool_dest_dir, remote_ncbitool_dest_dir,
             key_path, remote_username, server_ip, sudo)
         version_number = get_reference_version_number(local_ncbitool, ref_file)
-        input_fasta_remote = download_reference_on_remote(remote_ncbitool, ref_file, version_number, dest_dir,
+        input_fasta_remote = download_reference_on_remote(
+            remote_ncbitool, ref_file, version_number, dest_dir,
             key_path, remote_username, server_ip)
     return input_fasta_remote, version_number
 

--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -7,6 +7,7 @@ import logging
 import json
 import gzip
 import os
+import traceback
 
 NCBITOOL_S3_PATH = "s3://czbiohub-infectious-disease/ncbitool" # S3 location of ncbitool executable
 ACCESSION2TAXID = 's3://czbiohub-infectious-disease/references/accession2taxid.db.gz'
@@ -18,7 +19,6 @@ ROOT_DIR = '/mnt'
 DEST_DIR = ROOT_DIR + '/idseq/data' # generated data go here
 REF_DIR = ROOT_DIR + '/idseq/ref' # referene genome / ref databases go here
 
-STATS = []
 OUTPUT_VERSIONS = []
 
 print_lock = threading.RLock()
@@ -27,6 +27,64 @@ print_lock = threading.RLock()
 MAX_CONCURRENT_COPY_OPERATIONS = 8
 iostream = threading.Semaphore(MAX_CONCURRENT_COPY_OPERATIONS)
 
+
+class StatsFile(object):
+
+    def __init__(self, stats_filename, local_results_dir, s3_input_dir, s3_output_dir):
+        self.local_results_dir = local_results_dir
+        self.stats_filename = stats_filename
+        self.s3_input_dir = s3_input_dir
+        self.s3_output_dir = s3_output_dir
+        self.stats_path = os.path.join(self.local_results_dir, self.stats_filename)
+        self.data = []
+        self.mutex = threading.RLock()
+
+    def load_from_s3(self):
+        stats_s3_path = os.path.join(self.s3_input_dir, self.stats_filename)
+        if check_s3_file_presence(stats_s3_path):
+            execute_command("aws s3 cp --quiet %s %s/" % (stats_s3_path, self.local_results_dir))
+        self._load()
+
+    def _load(self):
+        if os.path.isfile(self.stats_path):
+            with open(self.stats_path) as f:
+                self.data = json.load(f)
+
+    def _save(self):
+        with open(self.stats_path, 'wb') as f:
+            json.dump(self.data, f)
+
+    def save_to_s3(self):
+        with self.mutex:
+            self._save()
+            execute_command("aws s3 cp --quiet %s %s/" % (self.stats_path, self.s3_output_dir))
+
+    def get_total_reads(self):
+        for item in self.data:
+            if "total_reads" in item:
+                return item["total_reads"]
+        # check run star if total reads not available
+        for item in self.data:
+            if item.get("task") == 'run_star':
+                return item["reads_before"]
+        # if no entry for run_star, host-filtering was skipped: use "remaining_reads" instead
+        return self.get_remaining_reads()
+        # previous fall-back value didn't fit into integer type of SQL dfatabase:
+        # return 0.1
+
+    def get_remaining_reads(self):
+        return (item for item in self.data if item.get("task") == "run_gsnapl_remotely").next().get("reads_before")
+
+    def count_reads(self, func_name, before_filename, before_filetype, after_filename, after_filetype):
+        records_before = count_reads(before_filename, before_filetype)
+        records_after = count_reads(after_filename, after_filetype)
+        new_data = [datum for datum in self.data if datum.get('task') != func_name]
+        if len(new_data) != len(self.data):
+            write_to_log("Overwriting counts for {}".format(func_name), warning=True)
+            self.data = new_data
+        self.data.append({'task': func_name, 'reads_before': records_before, 'reads_after': records_after})
+
+
 class MyThread(threading.Thread):
     def __init__(self, target, args):
         super(MyThread, self).__init__()
@@ -34,6 +92,7 @@ class MyThread(threading.Thread):
         self.target = target
         self.exception = None
         self.completed = False
+        self.result = None
 
     def run(self):
         try:
@@ -44,6 +103,7 @@ class MyThread(threading.Thread):
             self.exception = True
         finally:
             self.completed = True
+
 
 class Updater(object):
 
@@ -123,14 +183,22 @@ def execute_command(command, progress_file=None):
 
 
 def remote_command(base_command, key_path, remote_username, instance_ip):
-    return 'ssh -o "StrictHostKeyChecking no" -i %s %s@%s "%s"' % (key_path, remote_username, instance_ip, base_command)
+    return 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -i %s %s@%s "%s"' % (key_path, remote_username, instance_ip, base_command)
+
+
+def check_s3_file_presence(s3_path):
+    command = "aws s3 ls %s | wc -l" % s3_path
+    try:
+        return int(execute_command_with_output(command).rstrip())
+    except:
+        return 0
 
 
 def scp(key_path, remote_username, instance_ip, remote_path, local_path):
     assert " " not in key_path
     assert " " not in remote_path
     assert " " not in local_path
-    return 'scp -o "StrictHostKeyChecking no" -i {key_path} {username}@{ip}:{remote_path} {local_path}'.format(
+    return 'scp -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -i {key_path} {username}@{ip}:{remote_path} {local_path}'.format(
         key_path=key_path,
         username=remote_username,
         ip=instance_ip,
@@ -208,33 +276,6 @@ def configure_logger(log_file):
     LOGGER.addHandler(handler)
 
 
-def load_existing_stats(stats_file):
-    global STATS
-    if os.path.isfile(stats_file):
-        with open(stats_file) as f:
-            STATS = json.load(f)
-
-
-def get_total_reads_from_stats():
-    global STATS
-    for item in STATS:
-        if "total_reads" in item:
-            return item["total_reads"]
-    # check run star if total reads not available
-    for item in STATS:
-        if item.get("task") == 'run_star':
-            return item["reads_before"]
-    # if no entry for run_star, host-filtering was skipped: use "remaining_reads" instead
-    return get_remaining_reads_from_stats()
-    # previous fall-back value didn't fit into integer type of SQL dfatabase:
-    # return 0.1
-
-
-def get_remaining_reads_from_stats():
-    global STATS
-    return (item for item in STATS if item.get("task") == "run_gsnapl_remotely").next().get("reads_before")
-
-
 def fetch_from_s3(source, destination, auto_unzip, mutex=threading.RLock(), locks={}):  #pylint: disable=dangerous-default-value
     with mutex:
         if os.path.exists(destination):
@@ -304,10 +345,6 @@ def run_and_log_work(logparams, target_outputs, lazy_run, func_name, lazy_fetch,
     LOGGER = logging.getLogger()
     LOGGER.info("========== %s ==========", logparams.get("title"))
 
-    # copy log file -- start
-    LOGGER.handlers[0].flush()
-    execute_command("aws s3 cp --quiet %s %s/;" % (LOGGER.handlers[0].baseFilename, logparams["sample_s3_output_path"]))
-
     # record version of any reference index used
     version_file_s3 = logparams.get("version_file_s3")
     if version_file_s3:
@@ -336,32 +373,21 @@ def run_and_log_work(logparams, target_outputs, lazy_run, func_name, lazy_fetch,
     else:
         LOGGER.info("uploaded output")
 
-    # copy log file -- after work is done
-    execute_command("aws s3 cp --quiet %s %s/;" % (LOGGER.handlers[0].baseFilename, logparams["sample_s3_output_path"]))
 
-    # count records
-    required_params = ["before_file_name", "before_file_type", "after_file_name", "after_file_type"]
-    if logparams.get("count_reads") and all(param in logparams for param in required_params):
-        records_before = count_reads(logparams["before_file_name"], logparams["before_file_type"])
-        records_after = count_reads(logparams["after_file_name"], logparams["after_file_type"])
-        STATS.append({'task': func_name.__name__, 'reads_before': records_before, 'reads_after': records_after})
-
-    # copy log file -- end
-    LOGGER.handlers[0].flush()
-    execute_command("aws s3 cp --quiet %s %s/;" % (LOGGER.handlers[0].baseFilename, logparams["sample_s3_output_path"]))
-
-    # write stats
-    stats_path = logparams.get("stats_file")
-    if stats_path:
-        with open(stats_path, 'wb') as f:
-            json.dump(STATS, f)
-        execute_command("aws s3 cp --quiet %s %s/;" % (stats_path, logparams["sample_s3_output_path"]))
+def upload_log_file(sample_s3_output_path, lock=threading.RLock()):
+    with lock:
+        logh = logging.getLogger().handlers[0]
+        logh.flush()
+        execute_command("aws s3 cp --quiet %s %s/;" % (logh.baseFilename, sample_s3_output_path))
 
 
-def write_to_log(message, lock=threading.RLock()):
+def write_to_log(message, warning=False, lock=threading.RLock()):
     LOGGER = logging.getLogger()
     with lock:
-        LOGGER.info(message)
+        if warning:
+            LOGGER.warn(message)
+        else:
+            LOGGER.info(message)
 
 def unbuffer_stdout():
     # Unbuffer stdout and redirect stderr into stdout. This helps observe logged events in realtime.

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -360,7 +360,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
         {"title": "STAR",
          "version_file_s3": STAR_BOWTIE_VERSION_FILE_S3,
          "output_version_file": os.path.join(RESULT_DIR, VERSION_OUT)})
-    run_and_log_s3(logparams, target_outputs["run_star"], lazy_run, run_star, fastq_files)
+    run_and_log_s3(logparams, target_outputs["run_star"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_star, fastq_files)
     stats.count_reads("run_star",
                       before_filename=fastq_files[0],
                       before_filetype=initial_file_type_for_log,
@@ -373,7 +373,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
         input_files = [os.path.join(RESULT_DIR, STAR_OUT1), os.path.join(RESULT_DIR, STAR_OUT2)]
     else:
         input_files = [os.path.join(RESULT_DIR, STAR_OUT1)]
-    run_and_log_s3(logparams, target_outputs["run_priceseqfilter"], lazy_run, run_priceseqfilter, input_files)
+    run_and_log_s3(logparams, target_outputs["run_priceseqfilter"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_priceseqfilter, input_files)
     stats.count_reads("run_priceseqfilter",
                       before_filename=os.path.join(RESULT_DIR, STAR_OUT1),
                       before_filetype=initial_file_type_for_log,
@@ -389,7 +389,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
         else:
             input_files = [os.path.join(RESULT_DIR, PRICESEQFILTER_OUT1)]
             next_inputs = [os.path.join(RESULT_DIR, FQ2FA_OUT1)]
-        run_and_log_s3(logparams, target_outputs["run_fq2fa"], lazy_run, run_fq2fa, input_files)
+        run_and_log_s3(logparams, target_outputs["run_fq2fa"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_fq2fa, input_files)
     else:
         if number_of_input_files == 2:
             next_inputs = [os.path.join(RESULT_DIR, PRICESEQFILTER_OUT1), os.path.join(RESULT_DIR, PRICESEQFILTER_OUT2)]
@@ -398,7 +398,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
 
     # run cdhitdup
     logparams = return_merged_dict(DEFAULT_LOGPARAMS, {"title": "CD-HIT-DUP"})
-    run_and_log_s3(logparams, target_outputs["run_cdhitdup"], lazy_run, run_cdhitdup, next_inputs)
+    run_and_log_s3(logparams, target_outputs["run_cdhitdup"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_cdhitdup, next_inputs)
     stats.count_reads("run_cdhitdup",
                       before_filename=next_inputs[0],
                       before_filetype="fasta_paired",
@@ -412,7 +412,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
         input_files = [os.path.join(RESULT_DIR, CDHITDUP_OUT1), os.path.join(RESULT_DIR, CDHITDUP_OUT2)]
     else:
         input_files = [os.path.join(RESULT_DIR, CDHITDUP_OUT1)]
-    run_and_log_s3(logparams, target_outputs["run_lzw"], lazy_run, run_lzw, input_files)
+    run_and_log_s3(logparams, target_outputs["run_lzw"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_lzw, input_files)
     stats.count_reads("run_lzw",
                       before_filename=os.path.join(RESULT_DIR, CDHITDUP_OUT1),
                       before_filetype="fasta_paired",
@@ -425,7 +425,7 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats):
         input_files = [os.path.join(RESULT_DIR, LZW_OUT1), os.path.join(RESULT_DIR, LZW_OUT2)]
     else:
         input_files = [os.path.join(RESULT_DIR, LZW_OUT1)]
-    run_and_log_s3(logparams, target_outputs["run_bowtie2"], lazy_run, run_bowtie2, input_files)
+    run_and_log_s3(logparams, target_outputs["run_bowtie2"], lazy_run, SAMPLE_S3_OUTPUT_PATH, run_bowtie2, input_files)
     stats.count_reads("run_bowtie2",
                       before_filename=os.path.join(RESULT_DIR, LZW_OUT1),
                       before_filetype="fasta_paired",

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -20,17 +20,17 @@ chunks_in_flight = threading.Semaphore(MAX_CHUNKS_IN_FLIGHT)
 # Dispatch at most this many chunks per minute, to ensure fairness
 # amongst jobs regardless of job size (not the best way to do it,
 # just for now).
-MAX_DISPATCHES_PER_MINUTE = 5
+MAX_DISPATCHES_PER_MINUTE = 10
 
 # poll this many random servers per wait_for_instance_ip
 MAX_INSTANCES_TO_POLL = 5
 
 # If no instance is available, we should refresh our list of instances, to pick up new instances
 # added by autoscaling.  Wait at least this long between refreshes to stay within AWS account limits.
-MIN_INTERVAL_BETWEEN_DESCRIBE_INSTANCES = 300
+MIN_INTERVAL_BETWEEN_DESCRIBE_INSTANCES = 240
 
 # Refresh at least every 30 minutes
-MAX_INTERVAL_BETWEEN_DESCRIBE_INSTANCES = 1800
+MAX_INTERVAL_BETWEEN_DESCRIBE_INSTANCES = 1200
 
 # data directories
 ROOT_DIR = '/mnt'
@@ -78,8 +78,7 @@ SAMPLE_DIR = DEST_DIR + '/' + SAMPLE_NAME
 FASTQ_DIR = SAMPLE_DIR + '/fastqs'
 RESULT_DIR = SAMPLE_DIR + '/results'
 CHUNKS_RESULT_DIR = os.path.join(RESULT_DIR, "chunks")
-DEFAULT_LOGPARAMS = {"sample_s3_output_path": SAMPLE_S3_OUTPUT_PATH,
-                     "stats_file": os.path.join(RESULT_DIR, STATS_OUT)}
+DEFAULT_LOGPARAMS = {"sample_s3_output_path": SAMPLE_S3_OUTPUT_PATH}
 
 # For reproducibility of random operations
 random.seed(hash(SAMPLE_NAME))
@@ -134,7 +133,7 @@ def subsample_single_fasta(input_file, records_to_keep, type_, output_file):
     record_number = 0
     assert isinstance(records_to_keep, set), "Essential for this to complete in our lifetimes."
     kept_read_ids = set()
-    write_to_log(sorted(records_to_keep))
+    # write_to_log(sorted(records_to_keep))
     with open(input_file, 'rb') as input_f:
         with open(output_file, 'wb') as output_f:
             sequence_name = input_f.readline()
@@ -340,10 +339,10 @@ def check_pair_concordance(read_to_taxid):
     return species_taxid_concordance_map, genus_taxid_concordance_map, family_taxid_concordance_map
 
 def generate_json_from_taxid_counts(taxidCountsInputPath, jsonOutputPath, countType, lineage_map,
-                                    species_total_concordant, genus_total_concordant, family_total_concordant):
-    total_reads = get_total_reads_from_stats()
+                                    species_total_concordant, genus_total_concordant, family_total_concordant, stats):
+    total_reads = stats.get_total_reads()
     taxon_counts_attributes = []
-    remaining_reads = get_remaining_reads_from_stats()
+    remaining_reads = stats.get_remaining_reads()
 
     species_to_count = {}
     species_to_percent_identity = {}
@@ -399,9 +398,9 @@ def generate_json_from_taxid_counts(taxidCountsInputPath, jsonOutputPath, countT
         json.dump(output_dict, outf)
 
 
-def combine_pipeline_output_json(inputPath1, inputPath2, outputPath):
-    total_reads = get_total_reads_from_stats()
-    remaining_reads = get_remaining_reads_from_stats()
+def combine_pipeline_output_json(inputPath1, inputPath2, outputPath, stats):
+    total_reads = stats.get_total_reads()
+    remaining_reads = stats.get_remaining_reads()
     with open(inputPath1) as inf1:
         input1 = json.load(inf1).get("pipeline_output")
     with open(inputPath2) as inf2:
@@ -528,7 +527,7 @@ def wait_for_server_ip_work(service_name, key_path, remote_username, environment
         ip_nproc_dict = {}
         dict_mutex = threading.RLock()
         def poll_server(ip):
-            command = 'ssh -o "StrictHostKeyChecking no" -i %s %s@%s "ps aux | grep %s | grep -v bash" || echo "error"' % (key_path, remote_username, ip, service_name)
+            command = 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 5" -i %s %s@%s "ps aux | grep %s | grep -v bash" || echo "error"' % (key_path, remote_username, ip, service_name)
             output = execute_command_with_output(command).rstrip().split("\n")
             if output != ["error"]:
                 with dict_mutex:
@@ -561,7 +560,7 @@ def wait_for_server_ip_work(service_name, key_path, remote_username, environment
             return min_nproc_ip
         else:
             had_to_wait[0] = True
-            wait_seconds = random.randint(30, 60)
+            wait_seconds = random.randint(15, 60)
             print "%s servers busy. Wait for %d seconds" % \
                   (service_name, wait_seconds)
             time.sleep(wait_seconds)
@@ -585,14 +584,6 @@ def wait_for_server_ip(service_name, key_path, remote_username, environment, max
         # if we had to wait here, that counts toward the rate limit delay
         result = wait_for_server_ip_work(service_name, key_path, remote_username, environment, max_concurrent)
         return result
-
-
-def check_s3_file_presence(s3_path):
-    command = "aws s3 ls %s | wc -l" % s3_path
-    try:
-        return int(execute_command_with_output(command).rstrip())
-    except:
-        return 0
 
 
 # job functions
@@ -901,7 +892,7 @@ def run_rapsearch2_remotely(input_fasta, lazy_run):
 
 
 def run_generate_taxid_outputs_from_m8(annotated_m8, taxon_counts_csv_file, taxon_counts_json_file,
-                                       count_type, e_value_type):
+                                       count_type, e_value_type, stats):
 
     lineage_path = fetch_reference(LINEAGE_SHELF)
     lineage_map = shelve.open(lineage_path)
@@ -910,14 +901,14 @@ def run_generate_taxid_outputs_from_m8(annotated_m8, taxon_counts_csv_file, taxo
                                                                                           taxon_counts_csv_file, lineage_map)
     write_to_log("generated taxon counts from m8")
     generate_json_from_taxid_counts(taxon_counts_csv_file, taxon_counts_json_file, count_type,
-                                    lineage_map, species_concordant, genus_concordant, family_concordant)
+                                    lineage_map, species_concordant, genus_concordant, family_concordant, stats)
     write_to_log("generated JSON file from taxon counts")
     # move the output back to S3
     execute_command("aws s3 cp --quiet %s %s/" % (taxon_counts_csv_file, SAMPLE_S3_OUTPUT_PATH))
     execute_command("aws s3 cp --quiet %s %s/" % (taxon_counts_json_file, SAMPLE_S3_OUTPUT_PATH))
 
-def run_combine_json_outputs(input_json_1, input_json_2, output_json):
-    combine_pipeline_output_json(input_json_1, input_json_2, output_json)
+def run_combine_json_outputs(input_json_1, input_json_2, output_json, stats):
+    combine_pipeline_output_json(input_json_1, input_json_2, output_json, stats)
     write_to_log("finished job")
     # move it the output back to S3
     execute_command("aws s3 cp --quiet %s %s/" % (output_json, SAMPLE_S3_OUTPUT_PATH))
@@ -953,6 +944,9 @@ def run_stage2(lazy_run=True):
         _gsnapl_input_files = [EXTRACT_UNMAPPED_FROM_SAM_OUT1, EXTRACT_UNMAPPED_FROM_SAM_OUT2]
         before_file_name_for_log = os.path.join(RESULT_DIR, EXTRACT_UNMAPPED_FROM_SAM_OUT1)
         before_file_type_for_log = "fasta_paired"
+        # Import existing job stats
+        stats = StatsFile(STATS_OUT, RESULT_DIR, SAMPLE_S3_INPUT_PATH, SAMPLE_S3_OUTPUT_PATH)
+        stats.load_from_s3()
     else:
         # in case where previous stage was skipped, go back to original input
         command = "aws s3 ls %s/ | grep '\\.%s$'" % (SAMPLE_S3_FASTQ_PATH, FILE_TYPE)
@@ -972,6 +966,8 @@ def run_stage2(lazy_run=True):
         _merged_fasta = os.path.join(RESULT_DIR, EXTRACT_UNMAPPED_FROM_SAM_OUT3)
         generate_merged_fasta(cleaned_files, _merged_fasta)
         execute_command("aws s3 cp --quiet %s %s/" % (_merged_fasta, SAMPLE_S3_OUTPUT_PATH))
+        # Create new stats
+        stats = StatsFile(STATS_OUT, RESULT_DIR, None, SAMPLE_S3_OUTPUT_PATH)
 
     # Make sure there are no tabs in sequence names, since tabs are used as a delimiter in m8 files
     files_to_collapse_basenames = _gsnapl_input_files + [EXTRACT_UNMAPPED_FROM_SAM_OUT3]
@@ -984,13 +980,6 @@ def run_stage2(lazy_run=True):
         execute_command("aws s3 cp --quiet %s %s/" % (filename, SAMPLE_S3_OUTPUT_PATH))
     gsnapl_input_files = [os.path.basename(f) for f in collapsed_files[:-1]]
     merged_fasta = collapsed_files[-1]
-
-    # Import existing job stats
-    stats_s3_path = os.path.join(SAMPLE_S3_INPUT_PATH, STATS_OUT)
-    if check_s3_file_presence(stats_s3_path):
-        execute_command("aws s3 cp --quiet %s/%s %s/" % (SAMPLE_S3_INPUT_PATH, STATS_OUT, RESULT_DIR))
-        stats_file = os.path.join(RESULT_DIR, STATS_OUT)
-        load_existing_stats(stats_file)
 
     # subsample if specified
     if SUBSAMPLE:
@@ -1010,10 +999,9 @@ def run_stage2(lazy_run=True):
         # run gsnap remotely
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "GSNAPL", "count_reads": True,
-             "before_file_name": before_file_name_for_log, "before_file_type": before_file_type_for_log,
-             "after_file_name": os.path.join(RESULT_DIR, GSNAPL_DEDUP_OUT), "after_file_type": "m8",
-             "version_file_s3": GSNAP_VERSION_FILE_S3, "output_version_file": os.path.join(RESULT_DIR, VERSION_OUT)})
+            {"title": "GSNAPL",
+             "version_file_s3": GSNAP_VERSION_FILE_S3,
+             "output_version_file": os.path.join(RESULT_DIR, VERSION_OUT)})
         run_and_log_s3(
             logparams,
             TARGET_OUTPUTS["run_gsnapl_remotely"],
@@ -1022,11 +1010,16 @@ def run_stage2(lazy_run=True):
             run_gsnapl_remotely,
             gsnapl_input_files,
             lazy_run)
+        stats.count_reads("run_gsnapl_remotely",
+                          before_filename=before_file_name_for_log,
+                          before_filetype=before_file_type_for_log,
+                          after_filename=os.path.join(RESULT_DIR, GSNAPL_DEDUP_OUT),
+                          after_filetype="m8")
 
         # run_annotate_gsnapl_m8_with_taxids
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "annotate gsnapl m8 with taxids", "count_reads": False})
+            {"title": "annotate gsnapl m8 with taxids"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_annotate_m8_with_taxids__1"],
@@ -1035,9 +1028,7 @@ def run_stage2(lazy_run=True):
             os.path.join(RESULT_DIR, ANNOTATE_GSNAPL_M8_WITH_TAXIDS_OUT))
 
         # run_generate_taxid_annotated_fasta_from_m8
-        logparams = return_merged_dict(
-            DEFAULT_LOGPARAMS,
-            {"title": "generate taxid annotated fasta from m8", "count_reads": False})
+        logparams = return_merged_dict(DEFAULT_LOGPARAMS, {"title": "generate taxid annotated fasta from m8"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_generate_taxid_annotated_fasta_from_m8__1"],
@@ -1050,21 +1041,23 @@ def run_stage2(lazy_run=True):
         if SKIP_DEUTERO_FILTER:
             next_input = ANNOTATE_GSNAPL_M8_WITH_TAXIDS_OUT
         else:
-            logparams = return_merged_dict(
-                DEFAULT_LOGPARAMS,
-                {"title": "filter deuterostomes from m8__1", "count_reads": True,
-                 "before_file_name": os.path.join(RESULT_DIR, ANNOTATE_GSNAPL_M8_WITH_TAXIDS_OUT), "before_file_type": "m8",
-                 "after_file_name": os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NT_M8_OUT), "after_file_type": "m8"})
+            logparams = return_merged_dict(DEFAULT_LOGPARAMS, {"title": "filter deuterostomes from m8__1"})
             run_and_log_eager(
                 logparams, TARGET_OUTPUTS["run_filter_deuterostomes_from_m8__1"],
                 run_filter_deuterostomes_from_m8,
                 os.path.join(RESULT_DIR, ANNOTATE_GSNAPL_M8_WITH_TAXIDS_OUT),
                 os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NT_M8_OUT))
+            stats.count_reads("run_filter_deuterostomes_from_m8__1",
+                              before_filename=os.path.join(RESULT_DIR, ANNOTATE_GSNAPL_M8_WITH_TAXIDS_OUT),
+                              before_filetype="m8",
+                              after_filename=os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NT_M8_OUT),
+                              after_filetype="m8")
             next_input = FILTER_DEUTEROSTOMES_FROM_NT_M8_OUT
+
 
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "generate taxid outputs from m8", "count_reads": False})
+            {"title": "generate taxid outputs from m8"})
         run_and_log_eager(
             logparams, TARGET_OUTPUTS["run_generate_taxid_outputs_from_m8__1"],
             run_generate_taxid_outputs_from_m8,
@@ -1072,7 +1065,8 @@ def run_stage2(lazy_run=True):
             os.path.join(RESULT_DIR, NT_M8_TO_TAXID_COUNTS_FILE_OUT),
             os.path.join(RESULT_DIR, NT_TAXID_COUNTS_TO_JSON_OUT),
             'NT',
-            'raw')
+            'raw',
+            stats)
 
         with thread_success_lock:
             thread_success["gsnap"] = True
@@ -1080,10 +1074,7 @@ def run_stage2(lazy_run=True):
     def run_rapsearch2():
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "RAPSearch2", "count_reads": True,
-             "before_file_name": os.path.join(RESULT_DIR, merged_fasta),
-             "before_file_type": "fasta",
-             "after_file_name": os.path.join(RESULT_DIR, RAPSEARCH2_OUT), "after_file_type": "m8",
+            {"title": "RAPSearch2",
              "version_file_s3": RAPSEARCH_VERSION_FILE_S3, "output_version_file": os.path.join(RESULT_DIR, VERSION_OUT)})
         run_and_log_s3(
             logparams,
@@ -1093,6 +1084,11 @@ def run_stage2(lazy_run=True):
             run_rapsearch2_remotely,
             merged_fasta,
             lazy_run)
+        stats.count_reads("run_rapsearch2_remotely",
+                          before_filename=os.path.join(RESULT_DIR, merged_fasta),
+                          before_filetype="fasta",
+                          after_filename=os.path.join(RESULT_DIR, RAPSEARCH2_OUT),
+                          after_filetype="m8")
 
         with thread_success_lock:
             thread_success["rapsearch2"] = True
@@ -1101,7 +1097,7 @@ def run_stage2(lazy_run=True):
         # run_annotate_m8_with_taxids
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "annotate m8 with taxids", "count_reads": False})
+            {"title": "annotate m8 with taxids"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_annotate_m8_with_taxids__2"],
@@ -1112,22 +1108,23 @@ def run_stage2(lazy_run=True):
         if SKIP_DEUTERO_FILTER:
             next_input = ANNOTATE_RAPSEARCH2_M8_WITH_TAXIDS_OUT
         else:
-            logparams = return_merged_dict(
-                DEFAULT_LOGPARAMS,
-                {"title": "filter deuterostomes from m8", "count_reads": True,
-                 "before_file_name": os.path.join(RESULT_DIR, ANNOTATE_RAPSEARCH2_M8_WITH_TAXIDS_OUT), "before_file_type": "m8",
-                 "after_file_name": os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NR_M8_OUT), "after_file_type": "m8"})
+            logparams = return_merged_dict(DEFAULT_LOGPARAMS, {"title": "filter deuterostomes from m8"})
             run_and_log_eager(
                 logparams,
                 TARGET_OUTPUTS["run_filter_deuterostomes_from_m8__2"],
                 run_filter_deuterostomes_from_m8,
                 os.path.join(RESULT_DIR, ANNOTATE_RAPSEARCH2_M8_WITH_TAXIDS_OUT),
                 os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NR_M8_OUT))
+            stats.count_reads("run_filter_deuterostomes_from_m8__2",
+                              before_filename=os.path.join(RESULT_DIR, ANNOTATE_RAPSEARCH2_M8_WITH_TAXIDS_OUT),
+                              before_filetype="fasta",
+                              after_filename=os.path.join(RESULT_DIR, FILTER_DEUTEROSTOMES_FROM_NR_M8_OUT),
+                              after_filetype="m8")
             next_input = FILTER_DEUTEROSTOMES_FROM_NR_M8_OUT
 
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "generate taxid outputs from m8", "count_reads": False})
+            {"title": "generate taxid outputs from m8"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_generate_taxid_outputs_from_m8__2"],
@@ -1136,18 +1133,20 @@ def run_stage2(lazy_run=True):
             os.path.join(RESULT_DIR, NR_M8_TO_TAXID_COUNTS_FILE_OUT),
             os.path.join(RESULT_DIR, NR_TAXID_COUNTS_TO_JSON_OUT),
             'NR',
-            'log10')
+            'log10',
+            stats)
 
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "combine JSON outputs", "count_reads": False})
+            {"title": "combine JSON outputs"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_combine_json_outputs"],
             run_combine_json_outputs,
             RESULT_DIR + '/' + NT_TAXID_COUNTS_TO_JSON_OUT,
             RESULT_DIR + '/' + NR_TAXID_COUNTS_TO_JSON_OUT,
-            RESULT_DIR + '/' + COMBINED_JSON_OUT)
+            RESULT_DIR + '/' + COMBINED_JSON_OUT,
+            stats)
 
         with thread_success_lock:
             thread_success["additional_steps"] = True
@@ -1156,7 +1155,7 @@ def run_stage2(lazy_run=True):
         # run_generate_taxid_annotated_fasta_from_m8
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "generate taxid annotated fasta from m8", "count_reads": False})
+            {"title": "generate taxid annotated fasta from m8"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_generate_taxid_annotated_fasta_from_m8__2"],
@@ -1168,16 +1167,19 @@ def run_stage2(lazy_run=True):
 
         logparams = return_merged_dict(
             DEFAULT_LOGPARAMS,
-            {"title": "generate FASTA of unidentified reads", "count_reads": True,
-             "before_file_name": os.path.join(RESULT_DIR, GENERATE_TAXID_ANNOTATED_FASTA_FROM_RAPSEARCH2_M8_OUT),
-             "before_file_type": "fasta",
-             "after_file_name": os.path.join(RESULT_DIR, UNIDENTIFIED_FASTA_OUT), "after_file_type": "fasta"})
+            {"title": "generate FASTA of unidentified reads"})
         run_and_log_eager(
             logparams,
             TARGET_OUTPUTS["run_generate_unidentified_fasta"],
             run_generate_unidentified_fasta,
             RESULT_DIR + '/' + GENERATE_TAXID_ANNOTATED_FASTA_FROM_RAPSEARCH2_M8_OUT,
             RESULT_DIR + '/' + UNIDENTIFIED_FASTA_OUT)
+        stats.count_reads("run_generate_unidentified_fasta",
+                          before_filename=os.path.join(RESULT_DIR, GENERATE_TAXID_ANNOTATED_FASTA_FROM_RAPSEARCH2_M8_OUT),
+                          before_filetype="fasta",
+                          after_filename=os.path.join(RESULT_DIR, UNIDENTIFIED_FASTA_OUT),
+                          after_filetype="fasta")
+
 
         with thread_success_lock:
             thread_success["annotation"] = True
@@ -1204,3 +1206,7 @@ def run_stage2(lazy_run=True):
     assert thread_succeded("additional_steps")
     t_annotation.join()
     assert thread_succeded("annotation")
+
+    # copy log file -- after work is done
+    stats.save_to_s3()
+    upload_log_file(SAMPLE_S3_OUTPUT_PATH)

--- a/idseq_pipeline/commands/postprocess.py
+++ b/idseq_pipeline/commands/postprocess.py
@@ -10,4 +10,4 @@ class Postprocess(Base):
         unbuffer_stdout()
         upload_commit_sha(self.version)
 
-        run_stage3(True)
+        run_stage3(lazy_run=False)

--- a/idseq_pipeline/commands/postprocess_functions.py
+++ b/idseq_pipeline/commands/postprocess_functions.py
@@ -61,7 +61,6 @@ TARGET_OUTPUTS = {"run_generate_taxid_fasta_from_accid": [os.path.join(RESULT_DI
 
 # references
 # from common import ACCESSION2TAXID
-LINEAGE_SHELF = 's3://czbiohub-infectious-disease/references/taxid-lineages.db'
 
 # processing functions
 def accession2taxid(read_id, accession2taxid_dict, hit_type, lineage_map):
@@ -169,7 +168,10 @@ def run_combine_json(input_json_list, output_json):
     logging.getLogger().info("finished job")
     execute_command("aws s3 cp --quiet %s %s/" % (output_json, SAMPLE_S3_OUTPUT_PATH))
 
-def run_stage3(lazy_run=True):
+def run_stage3(lazy_run=False):
+
+    assert lazy_run == False, "we seem to be hardwiring that..."
+
     # make data directories
     execute_command("mkdir -p %s %s %s %s" % (SAMPLE_DIR, RESULT_DIR, REF_DIR, TEMP_DIR))
 
@@ -180,11 +182,6 @@ def run_stage3(lazy_run=True):
     # download input
     execute_command("aws s3 cp --quiet %s/%s %s/" % (SAMPLE_S3_INPUT_PATH, ACCESSION_ANNOTATED_FASTA, INPUT_DIR))
     input_file = os.path.join(INPUT_DIR, ACCESSION_ANNOTATED_FASTA)
-
-    if lazy_run:
-       # Download existing data and see what has been done
-        command = "aws s3 cp --quiet %s %s --recursive" % (SAMPLE_S3_OUTPUT_PATH, RESULT_DIR)
-        print execute_command(command)
 
     # generate taxid fasta
     logparams = return_merged_dict(


### PR DESCRIPTION
    small perf improvements and bug fixes
    
    * shorter connection timeout so dead machines don't hold up progress
    
    * double dispatch rate so big jobs can utilize more servers
    
    * get rid of global STATS
    
    * save stats at the end of stage 1 and 2
    
    * create empty stats at the start of stage 2 for jobs that have no stage 1
    
    * download fewer unneeded files from the result folder
