### PR TITLE
move ssh key

### DIFF
--- a/idseq_pipeline/cli.py
+++ b/idseq_pipeline/cli.py
@@ -46,7 +46,7 @@ Examples:
 
   INPUT_FASTA_S3=ftp://ftp.ensembl.org/pub/release-77/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references/human HOST_NAME=human idseq_pipeline host_indexing
 
-  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=s3://czbiohub-infectious-disease/idseq-production.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
+  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=s3://idseq-samples-production/keys/idseq-production.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
 
   INPUT_FASTA_S3=/blast/db/FASTA/nr.gz SERVER_IP=54.191.193.210 KEY_S3_PATH=s3://czbiohub-infectious-disease/idseq-alpha.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nr_rapsearch idseq_pipeline rapsearch_indexing
 

--- a/idseq_pipeline/cli.py
+++ b/idseq_pipeline/cli.py
@@ -46,7 +46,7 @@ Examples:
 
   INPUT_FASTA_S3=ftp://ftp.ensembl.org/pub/release-77/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references/human HOST_NAME=human idseq_pipeline host_indexing
 
-  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=s3://idseq-samples-production/keys/idseq-production.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
+  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=s3://idseq-secrets/idseq-production.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
 
   INPUT_FASTA_S3=/blast/db/FASTA/nr.gz SERVER_IP=54.191.193.210 KEY_S3_PATH=s3://czbiohub-infectious-disease/idseq-alpha.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nr_rapsearch idseq_pipeline rapsearch_indexing
 

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -469,7 +469,7 @@ def environment_for_aligners(_environment):
 
 def fetch_key(environment, mutex=threading.RLock()):
     with mutex:
-        key_s3_path = "s3://idseq-samples-production/keys/idseq-%s.pem" % environment_for_aligners(environment)
+        key_s3_path = "s3://idseq-secrets/idseq-%s.pem" % environment_for_aligners(environment)
         key_name = os.path.basename(key_s3_path)
         key_path = REF_DIR +'/' + key_name
         if not os.path.exists(key_path):

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -469,7 +469,7 @@ def environment_for_aligners(_environment):
 
 def fetch_key(environment, mutex=threading.RLock()):
     with mutex:
-        key_s3_path = "s3://czbiohub-infectious-disease/idseq-%s.pem" % environment_for_aligners(environment)
+        key_s3_path = "s3://idseq-samples-production/keys/idseq-%s.pem" % environment_for_aligners(environment)
         key_name = os.path.basename(key_s3_path)
         key_path = REF_DIR +'/' + key_name
         if not os.path.exists(key_path):

--- a/push_reference_update.sh
+++ b/push_reference_update.sh
@@ -36,7 +36,7 @@ aws s3 cp s3://czbiohub-infectious-disease/references/nt_k16.tar ${ARCHIVE_FOLDE
 aws s3 cp s3://czbiohub-infectious-disease/references/nt_k16.version.txt ${ARCHIVE_FOLDER}/
 
 echo 'Making new GSNAP index...'
-INPUT_FASTA_S3=${URL_PREFIX}/blast/db/FASTA/nt.gz SERVER_IP=${GSNAP_SERVER_IP} KEY_S3_PATH=s3://czbiohub-infectious-disease/idseq-production.pem OUTPUT_PATH_S3=$DESTINATION OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
+INPUT_FASTA_S3=${URL_PREFIX}/blast/db/FASTA/nt.gz SERVER_IP=${GSNAP_SERVER_IP} KEY_S3_PATH=s3://idseq-samples-production/keys/idseq-production.pem OUTPUT_PATH_S3=$DESTINATION OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
 
 ## Make RAPSearch2 index
 echo 'Archiving RAPSearch2 index...'

--- a/push_reference_update.sh
+++ b/push_reference_update.sh
@@ -36,7 +36,7 @@ aws s3 cp s3://czbiohub-infectious-disease/references/nt_k16.tar ${ARCHIVE_FOLDE
 aws s3 cp s3://czbiohub-infectious-disease/references/nt_k16.version.txt ${ARCHIVE_FOLDER}/
 
 echo 'Making new GSNAP index...'
-INPUT_FASTA_S3=${URL_PREFIX}/blast/db/FASTA/nt.gz SERVER_IP=${GSNAP_SERVER_IP} KEY_S3_PATH=s3://idseq-samples-production/keys/idseq-production.pem OUTPUT_PATH_S3=$DESTINATION OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
+INPUT_FASTA_S3=${URL_PREFIX}/blast/db/FASTA/nt.gz SERVER_IP=${GSNAP_SERVER_IP} KEY_S3_PATH=s3://idseq-secrets/idseq-production.pem OUTPUT_PATH_S3=$DESTINATION OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
 
 ## Make RAPSearch2 index
 echo 'Archiving RAPSearch2 index...'


### PR DESCRIPTION
I have already moved the key to the new location. Will delete it in old location once we push.

Next step:
When no jobs are running (no gsnap/rapsearch machines), delete the key pair in AWS and create a new one with same name. New gsnap/rapsearch machines should then start up with the new key.