### PR TITLE
(WIP) Parallelize / asynchronize some AWS cp calls

### DIFF
--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -665,8 +665,7 @@ class AsyncHandler:
         pass
 
     def launch(self, target, args):
-        with iostream:  # semaphore to limit max number of operations
-            t = threading.Thread(target=target, args=args)
+        t = threading.Thread(target=target, args=args)
         self.threads.append(t)
         t.start()
 
@@ -675,7 +674,10 @@ class AsyncHandler:
             t.join()
 
     def awsUpload(self, local, remote):
-        self.launch(execute_command("aws s3 cp --quiet %s %s" % (local, remote)), None)
+        self.launch(execute_command, "aws s3 cp --quiet %s %s" % (local, remote))
+
+    def launchCommand(self, command):
+        self.launch(execute_command, command)
 
 
 async_handler = AsyncHandler()

--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -657,3 +657,25 @@ fill_missing_calls_tests()
 
 def validate_taxid_lineage(taxid_lineage, hit_taxid_str, hit_level_str):
     return fill_missing_calls(cleaned_taxid_lineage(taxid_lineage, hit_taxid_str, hit_level_str))
+
+
+class AsyncHandler:
+    def __init__(self):
+        self.threads = []
+        pass
+
+    def launch(self, target, args):
+        with iostream:  # semaphore to limit max number of operations
+            t = threading.Thread(target=target, args=args)
+        self.threads.append(t)
+        t.start()
+
+    def wait_on_all(self):
+        for t in self.threads:
+            t.join()
+
+    def awsUpload(self, local, remote):
+        self.launch(execute_command("aws s3 cp --quiet %s %s" % (local, remote)), None)
+
+
+async_handler = AsyncHandler()

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -408,19 +408,19 @@ def run_priceseqfilter(input_fqs):
     execute_command_realtime_stdout(" ".join(priceseq_params))
     write_to_log("finished job")
     execute_command("mv %s %s" % (output_files[0], os.path.join(RESULT_DIR, PRICESEQFILTER_OUT1)))
-    async_handler.awsUpload(RESULT_DIR + "/" + PRICESEQFILTER_OUT1, SAMPLE_S3_OUTPUT_PATH)
+    async_handler.launch_aws_cp(RESULT_DIR + "/" + PRICESEQFILTER_OUT1, SAMPLE_S3_OUTPUT_PATH + "/")
     if len(input_fqs) == 2:
         execute_command("mv %s %s" % (output_files[1], os.path.join(RESULT_DIR, PRICESEQFILTER_OUT2)))
-        async_handler.awsUpload(RESULT_DIR + "/" + PRICESEQFILTER_OUT2, SAMPLE_S3_OUTPUT_PATH)
+        async_handler.launch_aws_cp(RESULT_DIR + "/" + PRICESEQFILTER_OUT2, SAMPLE_S3_OUTPUT_PATH + "/")
 
 def run_fq2fa(input_fqs):
     fq2fa(input_fqs[0], os.path.join(RESULT_DIR, FQ2FA_OUT1))
     if len(input_fqs) == 2:
         fq2fa(input_fqs[1], os.path.join(RESULT_DIR, FQ2FA_OUT2))
     write_to_log("finished job")
-    async_handler.awsUpload(RESULT_DIR + "/" + FQ2FA_OUT1, SAMPLE_S3_OUTPUT_PATH)
+    async_handler.launch_aws_cp(RESULT_DIR + "/" + FQ2FA_OUT1, SAMPLE_S3_OUTPUT_PATH + "/")
     if len(input_fqs) == 2:
-        async_handler.awsUpload(RESULT_DIR + "/" + FQ2FA_OUT2, SAMPLE_S3_OUTPUT_PATH)
+        async_handler.launch_aws_cp(RESULT_DIR + "/" + FQ2FA_OUT2, SAMPLE_S3_OUTPUT_PATH + "/")
 
 def run_cdhitdup(input_fas):
     cdhitdup_params = [CDHITDUP,

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -408,19 +408,19 @@ def run_priceseqfilter(input_fqs):
     execute_command_realtime_stdout(" ".join(priceseq_params))
     write_to_log("finished job")
     execute_command("mv %s %s" % (output_files[0], os.path.join(RESULT_DIR, PRICESEQFILTER_OUT1)))
-    execute_command("aws s3 cp --quiet %s/%s %s/;" % (RESULT_DIR, PRICESEQFILTER_OUT1, SAMPLE_S3_OUTPUT_PATH))
+    async_handler.awsUpload(RESULT_DIR + "/" + PRICESEQFILTER_OUT1, SAMPLE_S3_OUTPUT_PATH)
     if len(input_fqs) == 2:
         execute_command("mv %s %s" % (output_files[1], os.path.join(RESULT_DIR, PRICESEQFILTER_OUT2)))
-        execute_command("aws s3 cp --quiet %s/%s %s/;" % (RESULT_DIR, PRICESEQFILTER_OUT2, SAMPLE_S3_OUTPUT_PATH))
+        async_handler.awsUpload(RESULT_DIR + "/" + PRICESEQFILTER_OUT2, SAMPLE_S3_OUTPUT_PATH)
 
 def run_fq2fa(input_fqs):
     fq2fa(input_fqs[0], os.path.join(RESULT_DIR, FQ2FA_OUT1))
     if len(input_fqs) == 2:
         fq2fa(input_fqs[1], os.path.join(RESULT_DIR, FQ2FA_OUT2))
     write_to_log("finished job")
-    execute_command("aws s3 cp --quiet %s/%s %s/;" % (RESULT_DIR, FQ2FA_OUT1, SAMPLE_S3_OUTPUT_PATH))
+    async_handler.awsUpload(RESULT_DIR + "/" + FQ2FA_OUT1, SAMPLE_S3_OUTPUT_PATH)
     if len(input_fqs) == 2:
-        execute_command("aws s3 cp --quiet %s/%s %s/;" % (RESULT_DIR, FQ2FA_OUT2, SAMPLE_S3_OUTPUT_PATH))
+        async_handler.awsUpload(RESULT_DIR + "/" + FQ2FA_OUT2, SAMPLE_S3_OUTPUT_PATH)
 
 def run_cdhitdup(input_fas):
     cdhitdup_params = [CDHITDUP,
@@ -607,6 +607,7 @@ def run_stage1(lazy_run=True):
 
     # run host filtering
     run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats)
+    async_handler.wait_on_all()
 
     # This lets the webapp know the stage has completed.
     stats.save_to_s3()

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -663,9 +663,8 @@ def run_chunk(part_suffix, remote_home_dir, remote_index_dir, remote_work_dir, r
             try_number += 1
         # move output from remote machine to local
         assert min_column_number == correct_number_of_output_columns, "Chunk %s output corrupt; not copying to S3. Re-start pipeline to try again." % chunk_id
-        with iostream:
-            execute_command(scp(key_path, remote_username, instance_ip, multihit_remote_outfile, multihit_local_outfile))
-            async_handler.launch_aws_cp(multihit_local_outfile, SAMPLE_S3_OUTPUT_CHUNKS_PATH + "/")
+        execute_command(scp(key_path, remote_username, instance_ip, multihit_remote_outfile, multihit_local_outfile))
+        async_handler.launch_aws_cp(multihit_local_outfile, SAMPLE_S3_OUTPUT_CHUNKS_PATH + "/")
         write_to_log("finished alignment for chunk %s on %s server %s" % (chunk_id, service, instance_ip))
     return multihit_local_outfile
 

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -293,8 +293,7 @@ def annotate_fasta_with_accessions(merged_input_fasta, nt_m8, nr_m8, output_fast
                 sequence_name = input_fasta_f.readline()
                 sequence_data = input_fasta_f.readline()
 
-    execute_command("aws s3 cp --quiet %s %s/" % (output_fasta, SAMPLE_S3_OUTPUT_PATH))
-
+    async_handler.awsUpload(output_fasta, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def generate_taxon_count_json_from_m8(m8_file, hit_level_file, e_value_type, count_type, lineage_map_path, deuterostome_path, total_reads, remaining_reads, output_file, fork=True):

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -292,8 +292,7 @@ def annotate_fasta_with_accessions(merged_input_fasta, nt_m8, nr_m8, output_fast
                 output_fasta_f.write(sequence_data)
                 sequence_name = input_fasta_f.readline()
                 sequence_data = input_fasta_f.readline()
-
-    async_handler.awsUpload(output_fasta, SAMPLE_S3_OUTPUT_PATH + "/")
+    async_handler.launch_aws_cp(output_fasta, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def generate_taxon_count_json_from_m8(m8_file, hit_level_file, e_value_type, count_type, lineage_map_path, deuterostome_path, total_reads, remaining_reads, output_file, fork=True):
@@ -407,7 +406,7 @@ def generate_taxon_count_json_from_m8(m8_file, hit_level_file, e_value_type, cou
     }
     with open(output_file, 'wb') as outf:
         json.dump(output_dict, outf)
-    async_handler.awsUpload(output_file, SAMPLE_S3_OUTPUT_PATH + "/")
+    async_handler.launch_aws_cp(output_file, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def combine_pipeline_output_json(inputPath1, inputPath2, outputPath, stats):
@@ -429,7 +428,7 @@ def combine_pipeline_output_json(inputPath1, inputPath2, outputPath, stats):
     }
     with open(outputPath, 'wb') as outf:
         json.dump(output_dict, outf)
-    async_handler.awsUpload(outputPath, SAMPLE_S3_OUTPUT_PATH + "/")
+    async_handler.launch_aws_cp(outputPath, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def read_file_into_set(file_name):
@@ -575,7 +574,8 @@ def chunk_input(input_files_basenames, chunk_nlines, chunksize):
         out_prefix_base = os.path.basename(input_file) + part_suffix
         out_prefix = os.path.join(CHUNKS_RESULT_DIR, out_prefix_base)
         execute_command("split -a %d --numeric-suffixes -l %d %s %s" % (ndigits, chunk_nlines, input_file_full_local_path, out_prefix))
-        async_handler.launchCommand("aws s3 cp --quiet %s/ %s/ --recursive --exclude '*' --include '%s*'" % (CHUNKS_RESULT_DIR, SAMPLE_S3_OUTPUT_CHUNKS_PATH, out_prefix_base))
+        cmd_str = "aws s3 cp --quiet %s/ %s/ --recursive --exclude '*' --include '%s*'" % (CHUNKS_RESULT_DIR, SAMPLE_S3_OUTPUT_CHUNKS_PATH, out_prefix_base)
+        async_handler.launch_io_command(cmd_str)
         # note: no sleep(10) after this upload to s3... not sure if that was ever needed
         partial_files = [os.path.basename(partial_file) for partial_file in execute_command_with_output("ls %s*" % out_prefix).rstrip().split("\n")]
         pattern = "{:0%dd}" % ndigits
@@ -665,7 +665,7 @@ def run_chunk(part_suffix, remote_home_dir, remote_index_dir, remote_work_dir, r
         assert min_column_number == correct_number_of_output_columns, "Chunk %s output corrupt; not copying to S3. Re-start pipeline to try again." % chunk_id
         with iostream:
             execute_command(scp(key_path, remote_username, instance_ip, multihit_remote_outfile, multihit_local_outfile))
-            execute_command("aws s3 cp --quiet %s %s/" % (multihit_local_outfile, SAMPLE_S3_OUTPUT_CHUNKS_PATH))
+            async_handler.launch_aws_cp(multihit_local_outfile, SAMPLE_S3_OUTPUT_CHUNKS_PATH + "/")
         write_to_log("finished alignment for chunk %s on %s server %s" % (chunk_id, service, instance_ip))
     return multihit_local_outfile
 
@@ -739,9 +739,8 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path, output_m
                         emitted.add(read_id)
                         outf.write(line)
                         outf_sum.write("{read_id}\t{hit_level}\t{taxid}\n".format(read_id=read_id, hit_level=hit_level, taxid=taxid))
-    execute_command("aws s3 cp --quiet %s %s/" % (output_m8, SAMPLE_S3_OUTPUT_PATH))
-    execute_command("aws s3 cp --quiet %s %s/" % (output_summary, SAMPLE_S3_OUTPUT_PATH))
-
+    async_handler.launch_aws_cp(output_m8, SAMPLE_S3_OUTPUT_PATH + "/")
+    async_handler.launch_aws_cp(output_summary, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def run_remotely(input_files, service, lazy_run):
@@ -786,8 +785,7 @@ def run_remotely(input_files, service, lazy_run):
         check_for_errors(mutex, chunk_output_files, input_chunks, service)
     assert None not in chunk_output_files
     concatenate_files(chunk_output_files, result_dir(output_file))
-    with iostream:
-        execute_command("aws s3 cp --quiet %s/%s %s/" % (RESULT_DIR, output_file, SAMPLE_S3_OUTPUT_PATH))
+    async_handler.launch_aws_cp(RESULT_DIR + "/" + output_file, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def fetch_deuterostome_file(lock=threading.RLock()):  #pylint: disable=dangerous-default-value
@@ -826,7 +824,7 @@ def run_generate_unidentified_fasta(input_fa, output_fa):
     #TODO  remove annotated fasta intermediate file and replace > with : below
     subprocess.check_output("grep -A 1 '>NR::NT::' %s | sed '/^--$/d' > %s" % (input_fa, output_fa), shell=True)
     write_to_log("finished job")
-    execute_command("aws s3 cp --quiet %s %s/" % (output_fa, SAMPLE_S3_OUTPUT_PATH))
+    async_handler.launch_aws_cp(output_fa, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def get_alignment_version_s3_path():
@@ -847,10 +845,7 @@ def fetch_input_and_replace_whitespace(input_filename, result):
         result[0] = cleaned_input_path
         # This is extremely rare (debug/development only?) and we don't care if it succeeds
         if s3_input_path != s3_output_path:
-            threading.Thread(
-                target=execute_command,
-                args=["aws s3 cp --quiet {s3_input_path} {s3_output_path}".format(
-                    s3_input_path=s3_input_path, s3_output_path=s3_output_path)])
+            async_handler.launch_aws_cp(s3_input_path, s3_output_path)
 
 
 def fetch_and_clean_inputs():
@@ -927,13 +922,6 @@ def run_stage2(lazy_run=True):
     thread_success = {}
     thread_success_lock = threading.RLock()
 
-    uploader_threads = {}
-
-    def upload(thread_name, local_path, s3_path):
-        execute_command("aws s3 cp --quiet {local_path} {s3_path}".format(local_path=local_path, s3_path=s3_path))
-        with thread_success_lock:
-            thread_success[thread_name] = True
-
     # subsample if specified
     if SUBSAMPLE:
         target_n_reads = int(SUBSAMPLE)
@@ -945,13 +933,9 @@ def run_stage2(lazy_run=True):
         gsnapl_input_files = subsampled_gsnapl_input_files
         merged_fasta = result_dir(subsampled_merged_fasta)
         for i, f in enumerate(gsnapl_input_files):
-            thread_name = "uploader_{}".format(i)
-            uploader_threads[thread_name] = threading.Thread(target=upload, args=[thread_name, result_dir(f), SAMPLE_S3_OUTPUT_PATH + "/"])
-            uploader_threads[thread_name].start()
+            async_handler.launch_aws_cp(result_dir(f), SAMPLE_S3_OUTPUT_PATH + "/")
         if len(gsnapl_input_files) == 2:
-            thread_name = "uploader_{}".format(len(gsnapl_input_files))
-            uploader_threads[thread_name] = threading.Thread(target=upload, args=[thread_name, merged_fasta, SAMPLE_S3_OUTPUT_PATH + "/"])
-            uploader_threads[thread_name].start()
+            async_handler.launch_aws_cp(merged_fasta, SAMPLE_S3_OUTPUT_PATH + "/")
 
     deuterostome_fetcher = threading.Thread(target=fetch_deuterostome_file)
     deuterostome_fetcher.start()
@@ -1069,7 +1053,9 @@ def run_stage2(lazy_run=True):
         execute_command("echo This file is deprecated since pipeline version 1.5.  Please use {new} instead. > {deprecated}".format(
             deprecated=result_dir(DEPRECATED_BOOBYTRAPPED_COMBINED_JSON_OUT),
             new=MULTIHIT_COMBINED_JSON_OUT))
-        execute_command("aws s3 cp --quiet %s/%s %s/" % (RESULT_DIR, DEPRECATED_BOOBYTRAPPED_COMBINED_JSON_OUT, SAMPLE_S3_OUTPUT_PATH))
+        src = RESULT_DIR + "/" + DEPRECATED_BOOBYTRAPPED_COMBINED_JSON_OUT
+        dst = SAMPLE_S3_OUTPUT_PATH + "/"
+        async_handler.launch_aws_cp(src, dst)
 
         with thread_success_lock:
             thread_success["additional_steps"] = True
@@ -1122,10 +1108,6 @@ def run_stage2(lazy_run=True):
     assert thread_succeeded("additional_steps")
     t_annotation.join()
     assert thread_succeeded("annotation")
-
-    for thread_name, t in uploader_threads.items():
-        t.join()
-        assert thread_succeeded(thread_name), "thread {} failed".format(thread_name)
 
     # copy log file -- after work is done
     stats.save_to_s3()

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -407,7 +407,7 @@ def generate_taxon_count_json_from_m8(m8_file, hit_level_file, e_value_type, cou
     }
     with open(output_file, 'wb') as outf:
         json.dump(output_dict, outf)
-    execute_command("aws s3 cp --quiet %s %s/" % (output_file, SAMPLE_S3_OUTPUT_PATH))
+    async_handler.awsUpload(output_file, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def combine_pipeline_output_json(inputPath1, inputPath2, outputPath, stats):
@@ -429,8 +429,7 @@ def combine_pipeline_output_json(inputPath1, inputPath2, outputPath, stats):
     }
     with open(outputPath, 'wb') as outf:
         json.dump(output_dict, outf)
-    execute_command("aws s3 cp --quiet %s %s/" % (outputPath, SAMPLE_S3_OUTPUT_PATH))
-
+    async_handler.awsUpload(outputPath, SAMPLE_S3_OUTPUT_PATH + "/")
 
 
 def read_file_into_set(file_name):
@@ -576,7 +575,7 @@ def chunk_input(input_files_basenames, chunk_nlines, chunksize):
         out_prefix_base = os.path.basename(input_file) + part_suffix
         out_prefix = os.path.join(CHUNKS_RESULT_DIR, out_prefix_base)
         execute_command("split -a %d --numeric-suffixes -l %d %s %s" % (ndigits, chunk_nlines, input_file_full_local_path, out_prefix))
-        execute_command("aws s3 cp --quiet %s/ %s/ --recursive --exclude '*' --include '%s*'" % (CHUNKS_RESULT_DIR, SAMPLE_S3_OUTPUT_CHUNKS_PATH, out_prefix_base))
+        async_handler.launchCommand("aws s3 cp --quiet %s/ %s/ --recursive --exclude '*' --include '%s*'" % (CHUNKS_RESULT_DIR, SAMPLE_S3_OUTPUT_CHUNKS_PATH, out_prefix_base))
         # note: no sleep(10) after this upload to s3... not sure if that was ever needed
         partial_files = [os.path.basename(partial_file) for partial_file in execute_command_with_output("ls %s*" % out_prefix).rstrip().split("\n")]
         pattern = "{:0%dd}" % ndigits

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -1108,6 +1108,8 @@ def run_stage2(lazy_run=True):
     t_annotation.join()
     assert thread_succeeded("annotation")
 
+    async_handler.wait_on_all()
+
     # copy log file -- after work is done
     stats.save_to_s3()
     upload_log_file(SAMPLE_S3_OUTPUT_PATH)


### PR DESCRIPTION
- execute_command is blocking so for the appropriate "aws s3 cp" calls (mostly uploads) we can use a thread handler pattern instead.

- "with iostream" wraps the call in a semaphore / basically just limits the number of concurrent IO calls currently running.

- How does this look so far? If it's reasonable I'll change more calls in other files.