### PR TITLE
Remove hard-coded references to keypaths

### DIFF
--- a/idseq_pipeline/cli.py
+++ b/idseq_pipeline/cli.py
@@ -47,9 +47,9 @@ Examples:
 
   INPUT_FASTA_S3=ftp://ftp.ensembl.org/pub/release-77/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references/human HOST_NAME=human idseq_pipeline host_indexing
 
-  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=s3://idseq-secrets/idseq-production.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
+  INPUT_FASTA_S3=/blast/db/FASTA/nt.gz SERVER_IP=34.211.67.166 KEY_S3_PATH=<keypath> OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nt_k16 idseq_pipeline gsnap_indexing
 
-  INPUT_FASTA_S3=/blast/db/FASTA/nr.gz SERVER_IP=54.191.193.210 KEY_S3_PATH=s3://czbiohub-infectious-disease/idseq-alpha.pem OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nr_rapsearch idseq_pipeline rapsearch_indexing
+  INPUT_FASTA_S3=/blast/db/FASTA/nr.gz SERVER_IP=54.191.193.210 KEY_S3_PATH=<keypath> OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references OUTPUT_NAME=nr_rapsearch idseq_pipeline rapsearch_indexing
 
   OUTPUT_PATH_S3=s3://czbiohub-infectious-disease/references INPUT=/pub/taxonomy/taxdump.tar.gz idseq_pipeline lineages
 

--- a/idseq_pipeline/commands/push_reference_update.py
+++ b/idseq_pipeline/commands/push_reference_update.py
@@ -55,7 +55,6 @@ class Push_reference_update(Base):
         dest = os.environ["DEST_PREFIX"] + "/alignment_indexes/" + date
         os.environ["INPUT_FASTA_S3"] = os.environ["URL_PREFIX"] + self.nt
         os.environ["SERVER_IP"] = os.environ["GSNAP_SERVER_IP"]
-        os.environ["KEY_S3_PATH"] = "s3://idseq-secrets/idseq-production.pem"
         os.environ["OUTPUT_PATH_S3"] = dest
         os.environ["OUTPUT_NAME"] = "nt_k16"
         os.system("idseq_pipeline gsnap_indexing")
@@ -64,7 +63,6 @@ class Push_reference_update(Base):
         dest = os.environ["DEST_PREFIX"] + "/alignment_indexes/" + date
         os.environ["INPUT_FASTA_S3"] = os.environ["URL_PREFIX"] + self.nr
         os.environ["SERVER_IP"] = os.environ["RAPSEARCH_SERVER_IP"]
-        os.environ["KEY_S3_PATH"] = "s3://czbiohub-infectious-disease/idseq-alpha.pem"
         os.environ["OUTPUT_PATH_S3"] = dest
         os.environ["OUTPUT_NAME"] = "nr_rapsearch"
         os.system("idseq_pipeline rapsearch_indexing")


### PR DESCRIPTION
## What is this PR about? 
Removing hard-coded references to keypaths in s3

## Samples to test for 
- [ ] https://idseq.net/samples/3889
- [ ] https://idseq.net/samples/4000
- [ ] https://idseq.net/samples/3920
- [ ] https://idseq.net/samples/3006
- [ ] https://idseq.net/samples/4
- [ ] https://idseq.net/samples/2981
