### PR TITLE
Add another upload semaphore

### DIFF
--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -498,23 +498,12 @@ def fetch_from_s3(source,
             # It's okay if the parent directory already exists, but all other errors are fatal.
             if e.errno != os.errno.EEXIST:
                 raise
-        with iostream_uploads:  # Limit concurrent uploads so as not to stall the pipeline.
-            with iostream:      # Still counts toward the general semaphore.
-                try:
-                    if allow_s3mi:
-                        try:
-                            install_s3mi()
-                        except:
-                            allow_s3mi = False
-                    if unzip:
-                        pipe_filter = "| gzip -dc "
-                    else:
-                        pipe_filter = ""
+        with iostream:
+            try:
+                if allow_s3mi:
                     try:
-                        assert allow_s3mi
-                        execute_command("s3mi cat {source} {pipe_filter} > {destination}".format(source=source, pipe_filter=pipe_filter, destination=destination))
+                        install_s3mi()
                     except:
-<<<<<<< HEAD
                         allow_s3mi = False
                 if unzip:
                     pipe_filter = "| gzip -dc "
@@ -524,14 +513,14 @@ def fetch_from_s3(source,
                     assert allow_s3mi
                     execute_command(
                         "s3mi cat {source} {pipe_filter} > {destination}".
-                        format(
+                            format(
                             source=source,
                             pipe_filter=pipe_filter,
                             destination=destination))
                 except:
                     execute_command(
                         "aws s3 cp --quiet {source} - {pipe_filter} > {destination}".
-                        format(
+                            format(
                             source=source,
                             pipe_filter=pipe_filter,
                             destination=destination))
@@ -539,13 +528,6 @@ def fetch_from_s3(source,
             except subprocess.CalledProcessError:
                 # Most likely the file doesn't exist in S3.
                 return None
-=======
-                        execute_command("aws s3 cp --quiet {source} - {pipe_filter} > {destination}".format(source=source, pipe_filter=pipe_filter, destination=destination))
-                    return destination
-                except subprocess.CalledProcessError:
-                    # Most likely the file doesn't exist in S3.
-                    return None
->>>>>>> Add another upload semaphore
 
 
 def install_s3mi(installed={}, mutex=threading.RLock()):  #pylint: disable=dangerous-default-value

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -767,10 +767,11 @@ def upload_with_retries(from_f, to_f):
 
 def upload(from_f, to_f, status, status_lock=threading.RLock()):
     try:
-        with iostream:
-            upload_with_retries(from_f, to_f)
-        with status_lock:
-            status[from_f] = "success"
+        with iostream_uploads:  # Limit concurrent uploads so as not to stall the pipeline.
+            with iostream:      # Still counts toward the general semaphore.
+                upload_with_retries(from_f, to_f)
+            with status_lock:
+                status[from_f] = "success"
     except:
         with status_lock:
             status[from_f] = "error"

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -889,13 +889,14 @@ def run_chunk(part_suffix, remote_home_dir, remote_index_dir, remote_work_dir,
             try_number += 1
         # move output from remote machine to local
         assert min_column_number == correct_number_of_output_columns, "Chunk %s output corrupt; not copying to S3. Re-start pipeline to try again." % chunk_id
-        with iostream:
-            execute_command(
-                scp(key_path, remote_username, instance_ip,
-                    multihit_remote_outfile, multihit_local_outfile))
-            execute_command("aws s3 cp --quiet %s %s/" %
-                            (multihit_local_outfile,
-                             SAMPLE_S3_OUTPUT_CHUNKS_PATH))
+        with iostream_uploads:  # Limit concurrent uploads so as not to stall the pipeline.
+            with iostream:      # Still counts toward the general semaphore.
+                execute_command(
+                    scp(key_path, remote_username, instance_ip,
+                        multihit_remote_outfile, multihit_local_outfile))
+                execute_command("aws s3 cp --quiet %s %s/" %
+                                (multihit_local_outfile,
+                                 SAMPLE_S3_OUTPUT_CHUNKS_PATH))
         write_to_log("finished alignment for chunk %s on %s server %s" %
                      (chunk_id, service, instance_ip))
     return multihit_local_outfile
@@ -1126,9 +1127,10 @@ def run_remotely(input_files, service, lazy_run):
 
     # Concatenate the pieces and upload results
     concatenate_files(chunk_output_files, result_dir(output_file))
-    with iostream:
-        execute_command("aws s3 cp --quiet %s/%s %s/" %
-                        (RESULT_DIR, output_file, SAMPLE_S3_OUTPUT_PATH))
+    with iostream_uploads:  # Limit concurrent uploads so as not to stall the pipeline.
+        with iostream:      # Still counts toward the general semaphore.
+            execute_command("aws s3 cp --quiet %s/%s %s/" %
+                            (RESULT_DIR, output_file, SAMPLE_S3_OUTPUT_PATH))
 
 
 def fetch_deuterostome_file(lock=threading.RLock()):  #pylint: disable=dangerous-default-value


### PR DESCRIPTION
For #194 

- Basically create another upload semaphore to reserve some capacity for downloads or file moves to proceed. Interesting approach.

We have:
```
MAX_CONCURRENT_COPY_OPERATIONS = 8
iostream = multiprocessing.Semaphore(MAX_CONCURRENT_COPY_OPERATIONS)
# Make a second semaphore for uploads to reserve some capacity for downloads.
MAX_CONCURRENT_UPLOAD_OPERATIONS = 4
iostream_uploads = multiprocessing.Semaphore(MAX_CONCURRENT_UPLOAD_OPERATIONS)
```

Problem:
"when the number of concurrent uploads reaches 8, we stall the entire pipeline, because we can no longer download inputs for the next (ready) step due to the iostreams semaphore being maxed out; so the next step is delayed until a couple uploads complete; which may take several minutes"

This PR: Replaced:
```
with iostream:
```
with:
```
with iostream_uploads:
    with iostream:
```

- The diff looks a little bigger b/c git didn't match the nested if blocks that well.

- Test run for this change: https://staging.idseq.net/samples/550