### PR TITLE
Add ServerAliveInterval to SSH

### DIFF
--- a/idseq_pipeline/commands/common.py
+++ b/idseq_pipeline/commands/common.py
@@ -387,7 +387,7 @@ def execute_command_with_output(command,
 
 
 def remote_command(base_command, key_path, remote_username, instance_ip):
-    return 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -i %s %s@%s "%s"' % (
+    return 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -o "ServerAliveInterval 60" -i %s %s@%s "%s"' % (
         key_path, remote_username, instance_ip, base_command)
 
 
@@ -395,7 +395,7 @@ def scp(key_path, remote_username, instance_ip, remote_path, local_path):
     assert " " not in key_path
     assert " " not in remote_path
     assert " " not in local_path
-    return 'scp -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -i {key_path} {username}@{ip}:{remote_path} {local_path}'.format(
+    return 'scp -o "StrictHostKeyChecking no" -o "ConnectTimeout 15" -o "ServerAliveInterval 60" -i {key_path} {username}@{ip}:{remote_path} {local_path}'.format(
         key_path=key_path,
         username=remote_username,
         ip=instance_ip,

--- a/idseq_pipeline/commands/non_host_alignment_functions.py
+++ b/idseq_pipeline/commands/non_host_alignment_functions.py
@@ -586,7 +586,7 @@ def wait_for_server_ip_work(service_name,
         dict_writable = True
 
         def poll_server(ip):
-            command = 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 5" -i %s %s@%s "ps aux | grep %s | grep -v bash" || echo "error"' % (
+            command = 'ssh -o "StrictHostKeyChecking no" -o "ConnectTimeout 5" -o "ServerAliveInterval 60" -i %s %s@%s "ps aux | grep %s | grep -v bash" || echo "error"' % (
                 key_path, remote_username, ip, service_name)
             output = execute_command_with_output(
                 command, timeout=MAX_POLLING_LATENCY).rstrip().split("\n")


### PR DESCRIPTION
- Add ServerAliveInterval to try to prevent rapsearch SSH disconnects. Problem seems/seemed to be that rapsearch would finish processing but the Docker container runner would see the SSH connection as active and never close until finally the NAT firewall cuts them off after 2 hours.