### PR TITLE
Fix fasta_paired hardcoding

### DIFF
--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -976,9 +976,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
             next_inputs = [result_path(PRICESEQFILTER_OUT1)]
             if number_of_input_files == 2:
                 next_inputs.append(result_path(PRICESEQFILTER_OUT2))
-        initial_file_type_for_log = "fasta"
+        file_type_for_log = "fasta"
         if number_of_input_files == 2:
-            initial_file_type_for_log = "fasta_paired"
+            file_type_for_log = "fasta_paired"
 
         # Run CD-HIT-DUP
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,
@@ -989,9 +989,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_cdhitdup",
             before_filename=next_inputs[0],
-            before_filetype=initial_file_type_for_log,
+            before_filetype=file_type_for_log,
             after_filename=result_path(CDHITDUP_OUT1),
-            after_filetype=initial_file_type_for_log)
+            after_filetype=file_type_for_log)
 
         # Run LZW filter
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,
@@ -1005,9 +1005,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_lzw",
             before_filename=result_path(CDHITDUP_OUT1),
-            before_filetype=initial_file_type_for_log,
+            before_filetype=file_type_for_log,
             after_filename=result_path(LZW_OUT1),
-            after_filetype=initial_file_type_for_log)
+            after_filetype=file_type_for_log)
 
         # Run Bowtie
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,
@@ -1021,9 +1021,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_bowtie2",
             before_filename=result_path(LZW_OUT1),
-            before_filetype=initial_file_type_for_log,
+            before_filetype=file_type_for_log,
             after_filename=result_path(EXTRACT_UNMAPPED_FROM_BOWTIE_SAM_OUT1),
-            after_filetype=initial_file_type_for_log)
+            after_filetype=file_type_for_log)
 
     # Run GSNAP against host genomes (only available for Human as of 5/1/2018)
     # GSNAP may run again even for pre-filtered inputs
@@ -1045,9 +1045,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_gsnap_filter",
             before_filename=result_path(EXTRACT_UNMAPPED_FROM_BOWTIE_SAM_OUT1),
-            before_filetype=initial_file_type_for_log,
+            before_filetype=file_type_for_log,
             after_filename=result_path(EXTRACT_UNMAPPED_FROM_GSNAP_SAM_OUT1),
-            after_filetype=initial_file_type_for_log)
+            after_filetype=file_type_for_log)
     except SkipGsnap:
         write_to_log("Skipping gsnap for prefilterd input or too many reads")
         pass

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -976,6 +976,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
             next_inputs = [result_path(PRICESEQFILTER_OUT1)]
             if number_of_input_files == 2:
                 next_inputs.append(result_path(PRICESEQFILTER_OUT2))
+        initial_file_type_for_log = "fasta"
+        if number_of_input_files == 2:
+            initial_file_type_for_log = "fasta_paired"
 
         # Run CD-HIT-DUP
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,

--- a/idseq_pipeline/commands/host_filtering_functions.py
+++ b/idseq_pipeline/commands/host_filtering_functions.py
@@ -986,9 +986,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_cdhitdup",
             before_filename=next_inputs[0],
-            before_filetype="fasta_paired",
+            before_filetype=initial_file_type_for_log,
             after_filename=result_path(CDHITDUP_OUT1),
-            after_filetype="fasta_paired")
+            after_filetype=initial_file_type_for_log)
 
         # Run LZW filter
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,
@@ -1002,9 +1002,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_lzw",
             before_filename=result_path(CDHITDUP_OUT1),
-            before_filetype="fasta_paired",
+            before_filetype=initial_file_type_for_log,
             after_filename=result_path(LZW_OUT1),
-            after_filetype="fasta_paired")
+            after_filetype=initial_file_type_for_log)
 
         # Run Bowtie
         log_params = return_merged_dict(DEFAULT_LOG_PARAMS,
@@ -1018,9 +1018,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_bowtie2",
             before_filename=result_path(LZW_OUT1),
-            before_filetype="fasta_paired",
+            before_filetype=initial_file_type_for_log,
             after_filename=result_path(EXTRACT_UNMAPPED_FROM_BOWTIE_SAM_OUT1),
-            after_filetype="fasta_paired")
+            after_filetype=initial_file_type_for_log)
 
     # Run GSNAP against host genomes (only available for Human as of 5/1/2018)
     # GSNAP may run again even for pre-filtered inputs
@@ -1042,9 +1042,9 @@ def run_host_filtering(fastq_files, initial_file_type_for_log, lazy_run, stats,
         stats.count_reads(
             "run_gsnap_filter",
             before_filename=result_path(EXTRACT_UNMAPPED_FROM_BOWTIE_SAM_OUT1),
-            before_filetype="fasta_paired",
+            before_filetype=initial_file_type_for_log,
             after_filename=result_path(EXTRACT_UNMAPPED_FROM_GSNAP_SAM_OUT1),
-            after_filetype="fasta_paired")
+            after_filetype=initial_file_type_for_log)
     except SkipGsnap:
         write_to_log("Skipping gsnap for prefilterd input or too many reads")
         pass


### PR DESCRIPTION
- TEST RUN: https://staging.idseq.net/samples/836
- Initial file type gets set as like:
```
    initial_file_type_for_log = "fasta"
    if "fastq" in FILE_TYPE or "fq" in FILE_TYPE:
        initial_file_type_for_log = "fastq"
    if len(fastq_files) == 2:
        initial_file_type_for_log += "_paired"
```